### PR TITLE
Categorized index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,11 @@ GEM
     diff-lcs (1.3)
     erubi (1.7.1)
     execjs (2.7.0)
+    factory_bot (4.11.1)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
+      railties (>= 3.0.0)
     ffi (1.9.25)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -191,6 +196,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   coffee-rails (~> 4.2)
+  factory_bot_rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
@@ -210,4 +216,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,13 @@
+module OrdersHelper
+  
+  def order_table_id(shipped)
+    return 'shipped_orders' if shipped
+    'unshipped_orders'
+  end
+
+  def order_table_name(shipped)
+    return t('orders.shipped_orders') if shipped
+    t('orders.unshipped_orders')
+  end
+
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,4 +1,8 @@
 class Order < ApplicationRecord
+
+  scope :shipped, -> (direction = :desc) { where.not(shipped_at: nil).order(shipped_at: direction) }
+  scope :unshipped, -> { where(shipped_at: nil) }
+
   def expedited?
     @expedite
   end

--- a/app/views/orders/_orders_table.html.erb
+++ b/app/views/orders/_orders_table.html.erb
@@ -1,0 +1,19 @@
+<h2><%= order_table_name(shipped) %></h2>
+<table id="<%= order_table_id(shipped) %>">
+  <thead>
+    <th><%= t('orders.order_id') %></th>
+    <% if shipped %>
+      <th><%= t('orders.shipped_at') %></th>
+    <% end %>
+  </thead>
+  <tbody>
+    <% orders.find_each do |order| %>
+    <tr class="order_row">  
+      <td><%= link_to order.id, order_path(order) %></td>
+      <% if shipped %>
+        <td><%= order.shipped_at.to_formatted_s(:long) %></td>
+      <% end %>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -4,11 +4,7 @@
   </head>
   <body>
     <h1>Orders</h1>
-
-    <ul>
-    <% @orders.each do |order| %>
-      <li><%= link_to order.id, order_path(order) %></li>
-    <% end %>
-    </ul>
+    <%= render partial: 'orders_table', locals: {orders: @orders.shipped, shipped: true} %>
+    <%= render partial: 'orders_table', locals: {orders: @orders.unshipped, shipped: false} %>
   </body>
 </html>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,9 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  orders:
+    table_name: 'Orders'
+    shipped_orders: 'Shipped Orders'
+    unshipped_orders: 'Unshipped Orders'
+    order_id: 'Order ID'
+    shipped_at: 'Shipped At'

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :order do
+    trait :shipped do
+      shipped_at { DateTime.now }
+    end
+  end
+end

--- a/spec/requests/orders_controller_spec.rb
+++ b/spec/requests/orders_controller_spec.rb
@@ -2,11 +2,13 @@ require 'rails_helper'
 
 RSpec.describe OrdersController, type: :request do
   describe '#index' do
-    let!(:order) { Order.create! }
+    let!(:unshipped_orders) { FactoryBot.create_list(:order, 2) }
+    let!(:shipped_order) { FactoryBot.create_list(:order, 1, :shipped) }
+
     it 'should have the "Orders" title and order id on the page' do 
-      get '/orders'      
-      expect(response.body).to include('Orders')
-      expect(response.body).to include("#{order.id}")
+      get '/orders'
+      expect_order_table_to_have_orders(shipped: true)
+      expect_order_table_to_have_orders(shipped: false)
     end
   end
 
@@ -16,5 +18,25 @@ RSpec.describe OrdersController, type: :request do
       get "/orders/#{order.id}"
       expect(response.body).to include("Order #{order.id}")
     end
+  end
+
+  def count_orders(shipped: true)
+    Nokogiri.parse(response.body).css("#{table_id_selector(shipped: shipped)} > tbody > tr.order_row").count
+  end
+
+  def order_table(shipped: true)
+    Nokogiri.parse(response.body).css("#{table_id_selector(shipped: shipped)} > tbody")
+  end
+
+  def table_id_selector(shipped: true)
+    shipped ? '#shipped_orders' : '#unshipped_orders'
+  end
+
+  def expect_order_table_to_have_orders(shipped: true)
+    order_scope = shipped ? Order.shipped : Order.unshipped
+    expect(count_orders(shipped: shipped)).to eq(order_scope.count)
+    order_scope.pluck(:id).each do |order_id|
+      expect(order_table(shipped: shipped).to_html).to include("/orders/#{order_id}")
+    end    
   end
 end

--- a/spec/requests/orders_controller_spec.rb
+++ b/spec/requests/orders_controller_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe OrdersController, type: :request do
 
     it 'should have the "Orders" title and order id on the page' do 
       get '/orders'
+      expect_shipped_and_unshipped_tables_to_be_present
       expect_order_table_to_have_orders(shipped: true)
       expect_order_table_to_have_orders(shipped: false)
     end
@@ -38,5 +39,12 @@ RSpec.describe OrdersController, type: :request do
     order_scope.pluck(:id).each do |order_id|
       expect(order_table(shipped: shipped).to_html).to include("/orders/#{order_id}")
     end    
+  end
+
+  def expect_shipped_and_unshipped_tables_to_be_present
+    expect(response.body).to include(I18n.t('orders.shipped_orders'))
+    expect(response.body).to include("shipped_orders")
+    expect(response.body).to include(I18n.t('orders.unshipped_orders'))
+    expect(response.body).to include("unshipped")
   end
 end


### PR DESCRIPTION
#### Summary
Enhance the orders index page to include a Shipped and Unshipped section.  During this time, I added translations to the orders index page so text modifications could be easily made later, if need be.

#### Changes
----
1. Add a `shipped` scope to orders
2. Add an `unshipped` scope to orders
3. Add both shipped and unshipped tables to the order index page.
4. Add specs for ensuring the proper data appears on the orders index page.